### PR TITLE
Fix backticks and syntax highlighting in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Rive makes use of clang [vector builtins](https://reviews.llvm.org/D111529), whi
 ## Building skia projects
 ```sh
 cd skia/dependencies
-./make_skia.sh      // this will invoke get_skia.sh
+./make_skia.sh      # this will invoke get_skia.sh
 ```
 To build viewer (plus you'll needed CMake installed)
 ```sh

--- a/README.md
+++ b/README.md
@@ -20,57 +20,57 @@ The C++ runtime for Rive provides these runtime features:
 We use [premake5](https://premake.github.io/). The Rive dev team primarily works on MacOS. There is some work done by the community to also support Windows and Linux. PRs welcomed for specific platforms you wish to support! We encourage you to use premake as it's highly extensible and configurable for a variety of platforms.
 
 ## Build
-In the ```rive-cpp``` directory, run ```build.sh``` to debug build and ```build.sh release``` for a release build.
+In the `rive-cpp` directory, run `build.sh` to debug build and `build.sh release` for a release build.
 
 If you've put the `premake5` executable in the `rive-cpp/build` folder, you can run it with `PATH=.:$PATH ./build.sh`
 
 Rive makes use of clang [vector builtins](https://reviews.llvm.org/D111529), which are, as of 2022, still a work in progress. Please use clang and ensure you have the latest version.
 
 ## Building skia projects
-```
+```sh
 cd skia/dependencies
 ./make_skia.sh      // this will invoke get_skia.sh
 ```
 To build viewer (plus you'll needed CMake installed)
-```
+```sh
 ./make_viewer_dependencies.sh
 ```
 
 ## Testing
 Uses the [Catch2](https://github.com/catchorg/Catch2) testing framework.
 
-```
+```sh
 cd tests/unit_tests
 ./test.sh
 ```
 
-In the ```tests/unit_tests``` directory, run ```test.sh``` to compile and execute the tests.
+In the `tests/unit_tests` directory, run `test.sh` to compile and execute the tests.
 
 (if you've installed `premake5` in `rive-runtime/build`, you can run it with `PATH=../../build:$PATH ./test.sh`)
 
-The tests live in ```rive/test```. To add new tests, create a new ```xxx_test.cpp``` file here. The test harness will automatically pick up the new file.
+The tests live in `rive/test`. To add new tests, create a new `xxx_test.cpp` file here. The test harness will automatically pick up the new file.
 
-There's a VSCode command provided to ```run tests``` from the Tasks: Run Task command palette. 
+There's a VSCode command provided to `run tests` from the Tasks: Run Task command palette. 
 
 ## Code formatting
-rive-cpp uses clang-format, you can install it with brew on MacOS: ```brew install clang-format```.
+rive-cpp uses clang-format, you can install it with brew on MacOS: `brew install clang-format`.
 
 ## Memory checks
 Note that if you're on MacOS you'll want to install valgrind, which is somewhat complicated these days. This is the easiest solution (please PR a better one when it becomes available).
 
-```
+```sh
 brew tap LouisBrunner/valgrind
 brew install --HEAD LouisBrunner/valgrind/valgrind
 ```
 
-You can now run the all the tests through valgrind by running ```test.sh memory```.
+You can now run the all the tests through valgrind by running `test.sh memory`.
 
 ## Disassembly explorer
 If you want to examine the generated assembly code per cpp file, install [Disassembly Explorer](https://marketplace.visualstudio.com/items?itemName=dseight.disasexpl) in VSCode.
 
-A ```disassemble``` task is provided to compile and preview the generated assembly. You can reach it via the Tasks: Run Task command palette or you can bind it to a shortcut by editing your VSCode keybindings.json:
+A `disassemble` task is provided to compile and preview the generated assembly. You can reach it via the Tasks: Run Task command palette or you can bind it to a shortcut by editing your VSCode keybindings.json:
 
-```
+```json
 [
     {
         "key": "cmd+d",

--- a/renderer/README.md
+++ b/renderer/README.md
@@ -6,14 +6,14 @@ This directory contains the renderer code and an example for how to interface wi
 
 ## Clone the rive-runtime repo
 
-```
+```sh
 git clone https://github.com/rive-app/rive-runtime.git
 cd rive-runtime/renderer
 ```
 
 ## Build GLFW
 
-```
+```sh
 pushd ../skia/dependencies
 ./make_glfw.sh
 popd
@@ -21,20 +21,20 @@ popd
 
 ## Add build_rive.sh to $PATH
 
-```
+```sh
 export PATH="$PATH:$(realpath ../build)"
 ```
 
 ## Build & run
 
-```
+```sh
 build_rive.sh release
 out/release/path_fiddle [/path/to/my.riv]
 ```
 
 ## Build & serve for WebGL2
 
-```
+```sh
 build_rive.sh ninja wasm release
 cd out/wasm_release
 python3 -m http.server 5555

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -8,15 +8,15 @@ Rive is built to be platform and subsystem agnostic so you can plug-in any rende
 We currently provide build files for MacOS but we will be adding Windows and others soon too.
 ### MacOS
 All the build scripts are in viewer/build/macosx.
-```
+```sh
 cd viewer/build/macosx
 ```
 You can tell the build script to build and run a Viewer that's backed by a Metal view with our Skia renderer:
-```
+```sh
 ./build_viewer.sh metal skia run
 ```
 An OpenGL example using a tessellating renderer:
-```
+```sh
 ./build_viewer.sh gl tess run
 ```
 Both the Skia and Tess renderers work with either gl or metal options.


### PR DESCRIPTION
- Triple backticks don't do anything special in inline monospaced text, so I converted them to single backticks.
- Added language specifiers to triple-backtick fenced code blocks for shell scripts (`sh`) and JSON (`json`).
- Fixed C-style `//` comment, since bash uses `#` for comments.