### PR TITLE
chore: update links to libpng

### DIFF
--- a/dependencies/premake5_libpng.lua
+++ b/dependencies/premake5_libpng.lua
@@ -1,6 +1,6 @@
 require('setup_compiler')
 local dependency = require('dependency')
-libpng = dependency.github('glennrp/libpng', 'libpng16')
+libpng = dependency.github('pnggroup/libpng', 'libpng16')
 zlib = dependency.github('madler/zlib', '04f42ceca40f73e2978b50e93806c2a18c1281fc')
 
 includedirs({ './' })

--- a/dependencies/premake5_libpng_v2.lua
+++ b/dependencies/premake5_libpng_v2.lua
@@ -1,7 +1,7 @@
 dofile('rive_build_config.lua')
 
 local dependency = require('dependency')
-libpng = dependency.github('glennrp/libpng', 'libpng16')
+libpng = dependency.github('pnggroup/libpng', 'libpng16')
 zlib = dependency.github('madler/zlib', 'v1.3.1')
 
 includedirs({ './' })


### PR DESCRIPTION
An internal GitHub redirect already exists for this, however let's make it proper.