### PR TITLE
chore: ensure dashes are at least zero length when using fmodf

### DIFF
--- a/src/shapes/paint/dash.cpp
+++ b/src/shapes/paint/dash.cpp
@@ -14,6 +14,11 @@ Dash::Dash(float value, bool percentage)
 float Dash::normalizedLength(float contourLength) const
 {
     float right = lengthIsPercentage() ? 1.0f : contourLength;
+    if (right == 0.0f)
+    {
+        return 0.0f;
+    }
+
     float p = fmodf(length(), right);
     if (p < 0.0f)
     {


### PR DESCRIPTION
if the countorLength is 0, fmodf will result in a divide by zero.