### PR TITLE
chore: ensure dashes have a positive normalized length.

### DIFF
--- a/src/shapes/paint/dash_path.cpp
+++ b/src/shapes/paint/dash_path.cpp
@@ -71,6 +71,11 @@ ShapePaintPath* PathDasher::applyDash(const RawPath* source,
             {
                 const Dash* dash = dashes[dashIndex++ % dashes.size()];
                 float dashLength = dash->normalizedLength(contour->length());
+                if (dashLength <= 0.0f)
+                {
+                    dashIndex++;
+                    continue;
+                }
                 if (dashLength > contour->length())
                 {
                     dashLength = contour->length();


### PR DESCRIPTION
prior checks of normalizedLength only ensure that at least one dash is valid. this ensures infinite loops cannot happen.