### PR TITLE
Invalid DX resource flags cause rive renderer initialization to fail

### DIFF
--- a/renderer/include/rive/renderer/d3d12/d3d12_utils.hpp
+++ b/renderer/include/rive/renderer/d3d12/d3d12_utils.hpp
@@ -449,7 +449,7 @@ public:
     rcp<D3D12Buffer> makeUploadBuffer(
         UINT size,
         D3D12_RESOURCE_FLAGS bindFlags = D3D12_RESOURCE_FLAG_NONE,
-        D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_COPY_SOURCE,
+        D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_GENERIC_READ,
         D3D12_HEAP_FLAGS heapFlags = D3D12_HEAP_FLAG_NONE);
 
     rcp<D3D12VolatileBuffer> makeVolatileBuffer(
@@ -465,7 +465,7 @@ public:
         rcp<D3D12Buffer> uploadBuffer =
             makeUploadBuffer(sizeInBytes,
                              D3D12_RESOURCE_FLAG_NONE,
-                             D3D12_RESOURCE_STATE_COPY_SOURCE);
+                             D3D12_RESOURCE_STATE_GENERIC_READ);
         rcp<D3D12Buffer> constBuffer = makeBuffer(sizeInBytes,
                                                   D3D12_RESOURCE_FLAG_NONE,
                                                   D3D12_RESOURCE_STATE_COMMON);

--- a/renderer/src/d3d12/d3d12_utils.cpp
+++ b/renderer/src/d3d12/d3d12_utils.cpp
@@ -379,7 +379,7 @@ void D3D12VolatileBuffer::resizeBuffers(UINT newSize)
 {
     m_uploadBuffer = d3d()->makeUploadBuffer(newSize,
                                              D3D12_RESOURCE_FLAG_NONE,
-                                             D3D12_RESOURCE_STATE_COPY_SOURCE);
+                                             D3D12_RESOURCE_STATE_GENERIC_READ);
     m_gpuBuffer = d3d()->makeBuffer(newSize,
                                     m_bindFlags,
                                     D3D12_RESOURCE_STATE_COMMON,


### PR DESCRIPTION
https://github.com/rive-app/rive-runtime/issues/57