### PR TITLE
fix(emscripten): prevent argv use-after-free

### DIFF
--- a/renderer/path_fiddle/path_fiddle.cpp
+++ b/renderer/path_fiddle/path_fiddle.cpp
@@ -412,8 +412,8 @@ int main(int argc, const char** argv)
     // Override argc/argv with the window location hash string.
     char* hash = get_location_hash_str();
     std::stringstream ss(hash);
-    std::vector<std::string> hashStrs;
-    std::vector<const char*> hashArgs;
+    static std::vector<std::string> hashStrs;
+    static std::vector<const char*> hashArgs;
     std::string arg;
 
     hashStrs.push_back("index.html");


### PR DESCRIPTION
Previously, when overriding `argc/argv` from the window location hash, the code built temporary `std::vector<std::string>` and `std::vector<const char*>` on the stack, then reassigned `argv` to their `.data()`. Once the block ended, both vectors were destroyed, leaving `argv` pointing into freed memory (UAF).

This patch makes the vectors `static`, ensuring their storage lives for the entire program lifetime and preventing the invalid pointer access.