### PR TITLE
fix(path_fiddle): destroy scenes before artboards to avoid UAF

### DIFF
--- a/renderer/path_fiddle/path_fiddle.cpp
+++ b/renderer/path_fiddle/path_fiddle.cpp
@@ -91,8 +91,8 @@ std::vector<rive::rcp<rive::ViewModelInstance>> viewModelInstances;
 
 static void clear_scenes()
 {
-    artboards.clear();
     scenes.clear();
+    artboards.clear();
     viewModelInstances.clear();
 }
 


### PR DESCRIPTION
`clear_scenes()` previously cleared `artboards` before `scenes`. Since `Scene` objects are constructed from `Artboard` instances and may hold raw references back into them, this ordering risked use-after-free during `Scene` destruction.

Reorder the clears to: scenes → artboards → viewModelInstances, ensuring dependencies are released in safe order.