### PR TITLE
support faster texture updates for vulkan renderer

### DIFF
--- a/renderer/include/rive/renderer/vulkan/render_context_vulkan_impl.hpp
+++ b/renderer/include/rive/renderer/vulkan/render_context_vulkan_impl.hpp
@@ -67,6 +67,10 @@ public:
                                   uint32_t mipLevelCount,
                                   const uint8_t imageDataRGBAPremul[]) override;
 
+    rcp<Texture> makeImageTexture(uint32_t width, uint32_t height,
+                                  uint32_t mipLevelCount,
+                                  rcp<vkutil::Buffer> imageBufferRGBAPremul);
+
     void hotloadShaders(rive::Span<const uint32_t> spirvData);
 
 private:

--- a/renderer/include/rive/renderer/vulkan/vkutil.hpp
+++ b/renderer/include/rive/renderer/vulkan/vkutil.hpp
@@ -214,6 +214,9 @@ public:
     // Deferred mechanism for uploading image data without a command buffer.
     void scheduleUpload(const void* imageData, size_t imageDataSizeInBytes);
 
+    // Deferred mechanism for uploading image data without a command buffer.
+    void scheduleUpload(rcp<vkutil::Buffer> imageBuffer);
+
     void barrier(VkCommandBuffer,
                  const ImageAccess& dstAccess,
                  ImageAccessAction = ImageAccessAction::preserveContents,

--- a/renderer/src/vulkan/render_context_vulkan_impl.cpp
+++ b/renderer/src/vulkan/render_context_vulkan_impl.cpp
@@ -88,6 +88,20 @@ rcp<Texture> RenderContextVulkanImpl::makeImageTexture(
     return texture;
 }
 
+rcp<Texture> RenderContextVulkanImpl::makeImageTexture(
+    uint32_t width, uint32_t height, uint32_t mipLevelCount,
+    rcp<vkutil::Buffer> imageBufferRGBAPremul)
+{
+  assert(imageBufferRGBAPremul->info().size >= height * width * 4);
+  auto texture = m_vk->makeTexture2D({
+      .format = VK_FORMAT_R8G8B8A8_UNORM,
+      .extent = {width, height},
+      .mipLevels = mipLevelCount,
+  });
+  texture->scheduleUpload(imageBufferRGBAPremul);
+  return texture;
+}
+  
 // Renders color ramps to the gradient texture.
 class RenderContextVulkanImpl::ColorRampPipeline
 {

--- a/renderer/src/vulkan/vkutil.cpp
+++ b/renderer/src/vulkan/vkutil.cpp
@@ -271,14 +271,20 @@ Texture2D::Texture2D(rcp<VulkanContext> vk, VkImageCreateInfo info) :
 void Texture2D::scheduleUpload(const void* imageData,
                                size_t imageDataSizeInBytes)
 {
-    m_imageUploadBuffer = m_image->vk()->makeBuffer(
-        {
-            .size = imageDataSizeInBytes,
-            .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-        },
-        vkutil::Mappability::writeOnly);
-    memcpy(m_imageUploadBuffer->contents(), imageData, imageDataSizeInBytes);
-    m_imageUploadBuffer->flushContents();
+  rcp<vkutil::Buffer> imageUploadBuffer = m_image->vk()->makeBuffer(
+      {
+          .size = imageDataSizeInBytes,
+          .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+      },
+      vkutil::Mappability::writeOnly);
+  memcpy(imageUploadBuffer->contents(), imageData, imageDataSizeInBytes);
+  scheduleUpload(imageUploadBuffer);
+}
+
+void Texture2D::scheduleUpload(rcp<vkutil::Buffer> imageBuffer)
+{
+  m_imageUploadBuffer = imageBuffer;
+  m_imageUploadBuffer->flushContents();
 }
 
 void Texture2D::applyImageUploadBuffer(VkCommandBuffer commandBuffer)


### PR DESCRIPTION
the caller can now provide the vulkan buffer directly, avoiding an allocation and copy.