### PR TITLE
Fix duplicate symbol error when statically linking Skia and Rive

### DIFF
--- a/renderer/include/rive/renderer/render_context.hpp
+++ b/renderer/include/rive/renderer/render_context.hpp
@@ -806,7 +806,7 @@ private:
         uint32_t m_currentContourID;
 
         // Atlas for offscreen feathering.
-        std::unique_ptr<skgpu::RectanizerSkyline> m_atlasRectanizer;
+        std::unique_ptr<rive::RectanizerSkyline> m_atlasRectanizer;
         uint32_t m_atlasMaxX = 0;
         uint32_t m_atlasMaxY = 0;
         std::vector<PathDraw*> m_pendingAtlasDraws;

--- a/renderer/include/rive/renderer/sk_rectanizer_skyline.hpp
+++ b/renderer/include/rive/renderer/sk_rectanizer_skyline.hpp
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace skgpu
+namespace rive
 {
 // Pack rectangles and track the current silhouette
 // Based, in part, on Jukka Jylanki's work at http://clb.demon.fi
@@ -82,4 +82,4 @@ private:
     // at x,y.
     void addSkylineLevel(int skylineIndex, int x, int y, int width, int height);
 };
-} // End of namespace skgpu
+} // End of namespace rive

--- a/renderer/src/render_context.cpp
+++ b/renderer/src/render_context.cpp
@@ -592,7 +592,7 @@ bool RenderContext::LogicalFlush::allocateAtlasDraw(
         uint16_t atlasMaxSize = m_ctx->atlasMaxSize();
         // Use an atlas larger than atlasMaxSize if it's too small for the
         // request (meaning the render target is larger than atlasMaxSize).
-        m_atlasRectanizer = std::make_unique<skgpu::RectanizerSkyline>(
+        m_atlasRectanizer = std::make_unique<rive::RectanizerSkyline>(
             std::max(atlasMaxSize, drawWidth),
             std::max(atlasMaxSize, drawHeight));
     }

--- a/renderer/src/sk_rectanizer_skyline.cpp
+++ b/renderer/src/sk_rectanizer_skyline.cpp
@@ -15,7 +15,7 @@
 #include <algorithm>
 #include <cassert>
 
-namespace skgpu
+namespace rive
 {
 
 bool RectanizerSkyline::addRect(int width, int height, int16_t* x, int16_t* y)
@@ -152,4 +152,4 @@ void RectanizerSkyline::addSkylineLevel(int skylineIndex,
     }
 }
 
-} // End of namespace skgpu
+} // End of namespace rive


### PR DESCRIPTION
Fix linker error from duplicate RectanizerSkyline symbol when statically linking Skia and Rive

When both Skia and Rive are statically linked together, a duplicate symbol error occurs 
because both libraries define `skgpu::RectanizerSkyline`. This causes the linker to fail 
with "duplicate symbol" errors.

Changed Rive's implementation to use the `rive` namespace instead of `skgpu` to avoid 
the naming collision. This allows both libraries to coexist when statically linked.

Modified files:
- sk_rectanizer_skyline.hpp: Changed namespace from skgpu to rive
- sk_rectanizer_skyline.cpp: Changed namespace from skgpu to rive  
- render_context.cpp: Updated RectanizerSkyline references to use rive namespace