### PR TITLE
fix: use emulated TLS on 32-bit ARM Android to fix linker crashes

### DIFF
--- a/build/rive_build_config.lua
+++ b/build/rive_build_config.lua
@@ -537,6 +537,19 @@ if _OPTIONS['for_android'] then
         '-no-canonical-prefixes',
     })
 
+    -- Avoid native ELF TLS on 32-bit ARM. Android's linker on API < 29 cannot
+    -- resolve R_ARM_TLS_DTPMOD32 relocations (type 17), causing dlopen to fail
+    -- with "unknown reloc type 17" on armeabi-v7a devices running Android 7-9.
+    -- 1. -femulated-tls: converts C++ thread_local to emulated TLS calls.
+    -- 2. -DTLS=: overrides libhydrogen's __thread macro so hydro_random_context
+    --    becomes a plain static (safe: Rive scripting is single-threaded).
+    filter('options:arch=arm')
+    do
+        buildoptions({ '-femulated-tls' })
+        defines({ 'TLS=' })
+    end
+    filter({})
+
     linkoptions({
         '--sysroot=' .. ndk_toolchain .. '/sysroot',
         '-fdata-sections',


### PR DESCRIPTION
## Summary

Eliminate native ELF TLS relocations on armeabi-v7a (32-bit ARM) Android builds by adding two Premake build flags for `arch=arm`:

1. `-femulated-tls` — converts any C++ `thread_local` to emulated TLS calls
2. `-DTLS=` — overrides libhydrogen's `__thread` macro so `hydro_random_context` becomes a plain static variable

## Problem

Since rive-android 11.0.0, the compiled `librive-android.so` for armeabi-v7a contains a `R_ARM_TLS_DTPMOD32` relocation (type 17) that Android's dynamic linker cannot resolve on API < 29 (Android 7–9). This causes `dlopen` to fail with "unknown reloc type 17", resulting in:

- **`UnsatisfiedLinkError`**: JNI methods (e.g., `FileAssetLoader.constructor()`) have no native backing after the library fails to load
- **`MissingLibraryException`**: ReLinker cannot find native libraries during initialization

### Production impact (Phantom Wallet, last 7 days)

- **2,831 crash events** across **685 impacted users**
- 93% on Android 7–9, all armeabi-v7a architecture
- Affected devices: Samsung J-series, Huawei Y5/Y6, Infinix, Itel — significant user base in emerging markets

## Root Cause

The specific TLS symbol is `hydro_random_context` — a 64-byte `__thread` variable in **libhydrogen** (`impl/random.h` line 1, via the `TLS` macro in `impl/common.h` line 42):

```c
// impl/common.h:42
#define TLS __thread

// impl/random.h:1
static TLS struct {
    _hydro_attr_aligned_(16) uint8_t state[gimli_BLOCKBYTES];
    uint64_t counter;
    uint8_t  initialized;
    uint8_t  available;
} hydro_random_context;
```

libhydrogen is a dependency of the scripting (Luau) feature added in 11.0.0. When compiled with LTO (`-flto`), the `__thread` attribute persists in LLVM IR bitcode and generates a native TLS relocation in the final shared library — even when `-femulated-tls` is passed as a compile flag. The `-femulated-tls` flag only affects code generation for new `thread_local` declarations; it does not retroactively convert `__thread` variables that are already baked into LTO bitcode as native TLS.

### Why `-DTLS=` is safe

`hydro_random_context` becomes a plain `static` variable (no thread-local storage). This is safe because:
- Rive's scripting (Luau) context runs single-threaded on Android
- The random context is only accessed from the scripting execution path
- 10.5.1 (before scripting was added) had no TLS at all and worked fine

## Verification

Built `librive-android.so` for armeabi-v7a and compared using `llvm-readelf`:

| Build | R_ARM_TLS_DTPMOD32 | TLS segment | __tls_get_addr |
|---|---|---|---|
| 10.5.1 (known working) | 0 | None | None |
| 11.4.0 (unfixed) | 1 | Yes (64 bytes) | Yes |
| **11.4.0 + this fix** | **0** | **None** | **None** |

## Why only ARM32

- `arm64-v8a`: Uses different TLS relocation types that are supported on older API levels
- `x86`/`x86_64`: Not affected (different relocation model)
- Only 32-bit ARM + API < 29 is impacted

## Related

- Companion PR: rive-app/rive-android#451 (CMakeLists.txt change)
- https://github.com/rive-app/rive-android/issues/445
- https://github.com/rive-app/rive-android/issues/441