### PR TITLE
fix(scripting): remove diagnostic [activate] log

### DIFF
--- a/src/assets/script_asset.cpp
+++ b/src/assets/script_asset.cpp
@@ -337,11 +337,6 @@ bool ScriptAsset::initScriptedObjectWith(ScriptedObject* object)
                 name().c_str());
         return false;
     }
-    fprintf(stderr,
-            "[activate] script \"%s\" generatorFunctionRef=%u -> lua ref=%d\n",
-            name().c_str(),
-            generatorFunctionRef(),
-            ref);
     rive_lua_pushRef(state, ref);
 
     if (!m_initted)


### PR DESCRIPTION
Removes a log in `ScriptAsset::initScriptedObjectWith in script_asset.cpp` which seems to have been added during a recent refactor.

Relates to [this issue about the log appearing in projects using the @rive/react-webgl2
package](https://github.com/rive-app/rive-react/issues/422)