### PR TITLE
gl: route feathers to atlas on Mali-G52 to avoid PLS corruption

### DIFF
--- a/renderer/src/gl/render_context_gl_impl.cpp
+++ b/renderer/src/gl/render_context_gl_impl.cpp
@@ -192,12 +192,13 @@ RenderContextGLImpl::RenderContextGLImpl(
         // (5-10%) improvement from not using flat varyings.
         m_platformFeatures.avoidFlatVaryings = true;
     }
-    if (m_capabilities.isPowerVR)
+    if (m_capabilities.isPowerVR || strstr(rendererString, "Mali-G52"))
     {
-        // Vivo Y21 (PowerVR Rogue GE8320; OpenGL ES 3.2 build 1.13@5776728a)
-        // seems to hit some sort of reset condition that corrupts pixel local
-        // storage when rendering a complex feather. For now, feather directly
-        // to the screen on PowerVR; always go offscreen.
+        // PowerVR (Vivo Y21, Rogue GE8320; OpenGL ES 3.2 build 1.13@5776728a)
+        // and Mali-G52 (Panfrost, e.g. MediaTek MT8169) hit a reset condition
+        // that corrupts pixel local storage when rendering a complex feather
+        // directly into PLS. Route feathers through the offscreen atlas on
+        // these GPUs.
         m_platformFeatures.alwaysFeatherToAtlas = true;
     }
     m_platformFeatures.clipSpaceBottomUp = true;


### PR DESCRIPTION
  ## Problem
  
  On Mali-G52 (Panfrost driver, e.g. MediaTek MT8169), shapes rendered with a
  feather come out with corrupted/fringed edges, and the corruption can spread to
  other geometry rendered in the same pixel-local-storage (PLS) pass.
  
  ## Root cause
  
  When a complex feather is rasterized directly into pixel local storage (the
  `CoverageType::pixelLocalStorage` path selected in `PathDraw::SelectCoverageType`),
  the Mali-G52 driver corrupts the PLS planes. This is the same class of failure
  already documented and worked around for PowerVR in `RenderContextGLImpl`
  (`alwaysFeatherToAtlas`). Small feathers are unaffected because they already
  route to the atlas via the `atlasScaleFactor <= 0.5` check; only larger feathers
  fall through to the direct-to-PLS path.
  
  ## Fix
  
  Extend the existing `alwaysFeatherToAtlas` workaround (previously PowerVR-only) to
  Mali-G52, forcing feathers through the offscreen atlas instead of PLS.
  
  ## Verification
  
  Reproduced on a Mali-G52 device. The corruption is deterministic and appears only
  on frames that render a feather; feather-free frames are unaffected. Setting
  `alwaysFeatherToAtlas = true` eliminates the corruption, confirmed with an
  on-device build.
  
