### PR TITLE
feat(viewmodel): expose enum name in PropertyData

### DIFF
--- a/include/rive/viewmodel/runtime/viewmodel_runtime.hpp
+++ b/include/rive/viewmodel/runtime/viewmodel_runtime.hpp
@@ -16,6 +16,7 @@ struct PropertyData
 {
     DataType type;
     std::string name;
+    std::string enumName;
 };
 
 class ViewModelRuntime : public RefCnt<ViewModelRuntime>

--- a/src/viewmodel/runtime/viewmodel_runtime.cpp
+++ b/src/viewmodel/runtime/viewmodel_runtime.cpp
@@ -46,6 +46,7 @@ std::vector<PropertyData> ViewModelRuntime::buildPropertiesData(
     for (auto property : properties)
     {
         DataType type = DataType::none;
+        std::string enumName;
         switch (property->coreType())
         {
             case ViewModelPropertyString::typeKey:
@@ -66,8 +67,16 @@ std::vector<PropertyData> ViewModelRuntime::buildPropertiesData(
             case ViewModelPropertyEnum::typeKey:
             case ViewModelPropertyEnumCustomBase::typeKey:
             case ViewModelPropertyEnumSystemBase::typeKey:
+            {
                 type = DataType::enumType;
+                auto* dataEnum =
+                    static_cast<ViewModelPropertyEnum*>(property)->dataEnum();
+                if (dataEnum != nullptr)
+                {
+                    enumName = dataEnum->enumName();
+                }
                 break;
+            }
             case ViewModelPropertyTrigger::typeKey:
                 type = DataType::trigger;
                 break;
@@ -86,7 +95,7 @@ std::vector<PropertyData> ViewModelRuntime::buildPropertiesData(
             default:
                 break;
         }
-        props.push_back({type, property->name()});
+        props.push_back({type, property->name(), enumName});
     }
     return props;
 }


### PR DESCRIPTION
Adds `enumName` to `PropertyData` so callers can identify which enum type a view model property references without separately correlating against `File.enums()`.

Needed by rive-wasm to surface `enumName` through `getProperties()` for TypeScript schema/codegen use cases.