### PR TITLE
Shader Minifier Mesa Bugfix

### DIFF
--- a/renderer/src/shaders/minify.py
+++ b/renderer/src/shaders/minify.py
@@ -481,6 +481,10 @@ class Minifier:
                 out.write('\n')
             elif needs_whitespace and lasttoken_needs_whitespace:
                 out.write(' ')
+            elif tok.type == "ID" and lasttoken.type == "OP" and lasttoken.value == ")":
+                # Mesa can reject minified GLSL macro calls when the next
+                # identifier is directly adjacent, e.g. OUT(float2)foo.
+                out.write(' ')
 
             # is_newline will be false once we output the token (unless this value otherwise gets
             # updated).


### PR DESCRIPTION
Apparently, while compiling shaders, Mesa on some platforms rejects expressions like this:
`void fn(OUT(vec2)A)`

while accepting
`void fn(OUT(vec2) A)`

This change fixes that by adding a blank space there. The matching might be too broad, but I couldn't find any tests regarding minification, so I am not aware of any cases this might break things. In my experience, all previously rejected shaders are compiled successfully after this fix.

This is discovered with the help of AI tools. 