### PR TITLE
fix(command_queue): deleteFile now cascade-deletes live artboards and their state machines

### DIFF
--- a/include/rive/command_server.hpp
+++ b/include/rive/command_server.hpp
@@ -6,6 +6,7 @@
 
 #include "rive/command_queue.hpp"
 #include "rive/hit_result.hpp"
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -172,6 +173,14 @@ private:
                 }
 
                 m_artboardDependencies.erase(dependencyItr);
+            }
+            for (auto& fileDependency : m_fileDependencies)
+            {
+                auto& artboardVector = fileDependency.second;
+                artboardVector.erase(std::remove(artboardVector.begin(),
+                                                 artboardVector.end(),
+                                                 handle),
+                                     artboardVector.end());
             }
             m_artboards.erase(itr);
             std::unique_lock<std::mutex> lock(m_commandQueue->m_messageMutex);

--- a/src/command_server.cpp
+++ b/src/command_server.cpp
@@ -739,18 +739,23 @@ bool CommandServer::processCommands()
                 commandStream >> handle;
                 commandStream >> requestId;
                 lock.unlock();
-                m_files.erase(handle);
                 auto itr = m_fileDependencies.find(handle);
                 if (itr != m_fileDependencies.end())
                 {
-                    auto& artboardVector = itr->second;
+                    // Detach the dependency list before cascading:
+                    // cleanupArtboard un-registers artboards from
+                    // m_fileDependencies, which would otherwise mutate the
+                    // vector while we iterate it.
+                    auto artboardVector = std::move(itr->second);
+                    m_fileDependencies.erase(itr);
                     for (auto artboardHandle : artboardVector)
                     {
                         cleanupArtboard(artboardHandle, requestId);
                     }
-
-                    m_fileDependencies.erase(itr);
                 }
+                // Erase the file after the cascade; dependent artboards and
+                // state machines may reference file-owned data.
+                m_files.erase(handle);
                 std::unique_lock<std::mutex> messageLock(
                     m_commandQueue->m_messageMutex);
                 messageStream << CommandQueue::Message::fileDeleted;
@@ -1022,6 +1027,9 @@ bool CommandServer::processCommands()
                     {
                         m_artboardDependencies[handle] = {};
                         m_artboards[handle] = std::move(artboard);
+                        assert(m_fileDependencies.find(fileHandle) !=
+                               m_fileDependencies.end());
+                        m_fileDependencies[fileHandle].push_back(handle);
 
                         std::unique_lock<std::mutex> messageLock(
                             m_commandQueue->m_messageMutex);
@@ -1172,9 +1180,9 @@ bool CommandServer::processCommands()
                 commandStream >> handle;
                 commandStream >> requestId;
                 lock.unlock();
+                // cleanupArtboard also un-registers the artboard from
+                // m_fileDependencies.
                 cleanupArtboard(handle, requestId);
-                // We don't remove from the file dependencies here because
-                // calling erase on a non existent key is fine.
                 break;
             }
 

--- a/tests/unit_tests/runtime/command_queue_test.cpp
+++ b/tests/unit_tests/runtime/command_queue_test.cpp
@@ -264,6 +264,115 @@ TEST_CASE("state machine management", "[CommandQueue]")
     serverThread.join();
 }
 
+TEST_CASE("deleteFile cascade-deletes live artboards and their state machines",
+          "[CommandQueue]")
+{
+    auto commandQueue = make_rcp<CommandQueue>();
+    std::thread serverThread(server_thread, commandQueue);
+
+    std::ifstream stream("assets/multiple_state_machines.riv",
+                         std::ios::binary);
+    FileHandle fileHandle = commandQueue->loadFile(
+        std::vector<uint8_t>(std::istreambuf_iterator<char>(stream), {}));
+    ArtboardHandle artboardHandle1 =
+        commandQueue->instantiateDefaultArtboard(fileHandle);
+    ArtboardHandle artboardHandle2 =
+        commandQueue->instantiateDefaultArtboard(fileHandle);
+    StateMachineHandle sm1 =
+        commandQueue->instantiateStateMachineNamed(artboardHandle1, "one");
+    StateMachineHandle sm2 =
+        commandQueue->instantiateStateMachineNamed(artboardHandle2, "two");
+    commandQueue->runOnce([fileHandle,
+                           artboardHandle1,
+                           artboardHandle2,
+                           sm1,
+                           sm2](CommandServer* server) {
+        REQUIRE(server->getFile(fileHandle) != nullptr);
+        REQUIRE(server->getArtboardInstance(artboardHandle1) != nullptr);
+        REQUIRE(server->getArtboardInstance(artboardHandle2) != nullptr);
+        REQUIRE(server->getStateMachineInstance(sm1) != nullptr);
+        REQUIRE(server->getStateMachineInstance(sm2) != nullptr);
+    });
+
+    // Delete the file WITHOUT deleting its artboards or state machines first.
+    // The file's dependency cascade must clean all of them up.
+    commandQueue->deleteFile(fileHandle);
+    commandQueue->runOnce([fileHandle,
+                           artboardHandle1,
+                           artboardHandle2,
+                           sm1,
+                           sm2](CommandServer* server) {
+        CHECK(server->getFile(fileHandle) == nullptr);
+        CHECK(server->getArtboardInstance(artboardHandle1) == nullptr);
+        CHECK(server->getArtboardInstance(artboardHandle2) == nullptr);
+        CHECK(server->getStateMachineInstance(sm1) == nullptr);
+        CHECK(server->getStateMachineInstance(sm2) == nullptr);
+    });
+
+    commandQueue->disconnect();
+    serverThread.join();
+}
+
+TEST_CASE("explicit deletes before deleteFile do not double-clean",
+          "[CommandQueue]")
+{
+    auto commandQueue = make_rcp<CommandQueue>();
+    std::thread serverThread(server_thread, commandQueue);
+
+    std::ifstream stream("assets/multiple_state_machines.riv",
+                         std::ios::binary);
+    FileHandle fileHandle = commandQueue->loadFile(
+        std::vector<uint8_t>(std::istreambuf_iterator<char>(stream), {}));
+    ArtboardHandle artboardHandle =
+        commandQueue->instantiateDefaultArtboard(fileHandle);
+    StateMachineHandle sm =
+        commandQueue->instantiateStateMachineNamed(artboardHandle, "one");
+
+    commandQueue->deleteStateMachine(sm);
+    commandQueue->deleteArtboard(artboardHandle);
+    commandQueue->deleteFile(fileHandle);
+    commandQueue->runOnce(
+        [fileHandle, artboardHandle, sm](CommandServer* server) {
+            CHECK(server->getFile(fileHandle) == nullptr);
+            CHECK(server->getArtboardInstance(artboardHandle) == nullptr);
+            CHECK(server->getStateMachineInstance(sm) == nullptr);
+        });
+
+    commandQueue->disconnect();
+    serverThread.join();
+}
+
+TEST_CASE("commands on cascade-deleted handles are safely rejected",
+          "[CommandQueue]")
+{
+    auto commandQueue = make_rcp<CommandQueue>();
+    std::thread serverThread(server_thread, commandQueue);
+
+    std::ifstream stream("assets/multiple_state_machines.riv",
+                         std::ios::binary);
+    FileHandle fileHandle = commandQueue->loadFile(
+        std::vector<uint8_t>(std::istreambuf_iterator<char>(stream), {}));
+    ArtboardHandle artboardHandle =
+        commandQueue->instantiateDefaultArtboard(fileHandle);
+    StateMachineHandle sm =
+        commandQueue->instantiateStateMachineNamed(artboardHandle, "one");
+
+    commandQueue->deleteFile(fileHandle);
+
+    // The client still holds handles to the cascade-deleted objects; using
+    // them must route through the normal unknown-handle error path.
+    commandQueue->advanceStateMachine(sm, 0.016f);
+    commandQueue->deleteStateMachine(sm);
+    commandQueue->deleteArtboard(artboardHandle);
+    commandQueue->runOnce([artboardHandle, sm](CommandServer* server) {
+        CHECK(server->getArtboardInstance(artboardHandle) == nullptr);
+        CHECK(server->getStateMachineInstance(sm) == nullptr);
+    });
+
+    commandQueue->disconnect();
+    serverThread.join();
+}
+
 TEST_CASE("default artboard & state machine", "[CommandQueue]")
 {
     auto commandQueue = make_rcp<CommandQueue>();


### PR DESCRIPTION
`CommandServer::m_fileDependencies[file]` is created empty at `loadFile` and walked by `deleteFile` to cascade-delete dependents, but `instantiateArtboard` never appends to it — so the cascade is always a no-op. Deleting a file while artboards instantiated from it are still alive orphans them (and their state machines) server-side, with no remaining documented cleanup path. Existing tests mask this by always deleting artboards explicitly before the file.

This PR:

1. Registers the artboard in `m_fileDependencies` at `instantiateArtboard`, mirroring how `instantiateStateMachine` registers in `m_artboardDependencies`.
2. Un-registers it in `cleanupArtboard`, so explicit create/delete cycles on a long-lived file don't grow the dependency vector unboundedly.
3. Makes `deleteFile` detach the dependency list before cascading (since `cleanupArtboard` now mutates it), and erases the file only after the cascade, since dependent artboards and state machines may reference file-owned data.

Tests added to `command_queue_test.cpp` (the first one fails without the fix):

1. `deleteFile` with two live artboards + state machines cleans all of them up.
2. Explicit deletes followed by `deleteFile` stay idempotent.
3. Commands on cascade-deleted handles go through the normal unknown-handle error path.

Full unit test suite passes.