### PR TITLE
fix(shaders): improve compatibility with older Adreno and Mesa GLSL compilers

### DIFF
--- a/renderer/src/shaders/draw_path_common.glsl
+++ b/renderer/src/shaders/draw_path_common.glsl
@@ -862,6 +862,11 @@ INLINE half incremental_clockwise_coverage(half c0, half c1, half paintAlpha)
     return (c1 - c0) / max(1. - c0 * paintAlpha, EPSILON_FP16_NON_DENORM);
 }
 
+// Older Adreno GLSL compilers can miscompile non-atomic path shaders when they
+// contain the unused unsigned shifts below. Keep this helper in storage-buffer
+// PLS and clockwise-atomic variants, where it is used or was already present.
+#if defined(@PLS_IMPL_STORAGE_BUFFER) ||                                    \
+    defined(@RENDER_MODE_CLOCKWISE_ATOMIC)
 // Converts an x,y image coordinate into a buffer index, swizzling into
 // BUFFER_IMAGE_TILE_SIZE x BUFFER_IMAGE_TILE_SIZE tiles for better cache
 // performance.
@@ -879,6 +884,7 @@ INLINE uint swizzle_image_buffer_idx(uint2 imageCoord, uint imageWidth)
     idx += ((imageCoord.y & 0x3u) << 2) + (imageCoord.x & 0x3u);
     return idx;
 }
+#endif
 
 #ifdef @RENDER_MODE_CLOCKWISE_ATOMIC
 

--- a/renderer/src/shaders/minify.py
+++ b/renderer/src/shaders/minify.py
@@ -479,7 +479,11 @@ class Minifier:
             # Adding this calling_token_type != 'DEFINE' prevents us from adding a new line to stringify macros
             if is_directive and not is_newline and calling_token_type != 'DEFINE':
                 out.write('\n')
-            elif needs_whitespace and lasttoken_needs_whitespace:
+            # Mesa 20.3 can merge a function-like macro's expansion with an
+            # immediately following identifier (e.g. OUT(float2)A -> out float2A).
+            elif (needs_whitespace and lasttoken_needs_whitespace) or (
+                tok.type == "ID" and lasttoken.type == "OP" and lasttoken.value == ")"
+            ):
                 out.write(' ')
 
             # is_newline will be false once we output the token (unless this value otherwise gets


### PR DESCRIPTION
## Summary

This PR contains two independent Android/OpenGL shader compatibility fixes, kept as separate commits:

1. **Adreno path-shader fix**  
   Emit `swizzle_image_buffer_idx` only for storage-buffer PLS and clockwise-atomic shader variants. This keeps its unused unsigned shifts out of unrelated path shaders that older Adreno GLSL compilers can silently miscompile.

2. **Mesa minifier fix**  
   Preserve a token separator when a closing parenthesis is immediately followed by an identifier. This prevents older Mesa preprocessors from merging the final token of a function-like macro expansion with the following identifier.

These fixes address different driver failures and do not depend on device-model checks or runtime allowlists.

## Problem 1: silent path-shader miscompile on older Adreno

After the storage-buffer PLS work in `365421d6`, `swizzle_image_buffer_idx` became part of every path shader, even when it was unused.

On Android 8.1 with an Adreno 616, the older GLSL compiler silently miscompiles non-atomic path shaders containing the helper's unused unsigned shifts. Filled and stroked vector paths disappear, while image meshes continue to render.

The regression was bisected to:

- `runtime-v0.1.118`: renders correctly
- `runtime-v0.1.119`: first broken release
- first bad commit: `365421d6177757772a911f176241af8ea6d5e64e`

The helper is required by `PLS_IMPL_STORAGE_BUFFER`. Clockwise-atomic variants also contained the previous swizzle helper before that commit. Restricting it to those two configurations restores the previous shader contents for unrelated path variants while preserving its required uses.

## Problem 2: macro-token merge on older Mesa

The GLSL minifier previously removed whitespace between a closing parenthesis and a following identifier. That is normally safe because the preprocessor operates on tokens, but Mesa 20.3.4 under virgl can incorrectly merge the final token of a function-like macro expansion with the following identifier.

For example:

```glsl
#define OUT(TYPE) out TYPE
OUT(vec2)v_position;
```

A conforming preprocessor treats the declaration as:

```glsl
out vec2 v_position;
```

On the affected Mesa compiler, the minified form can instead be interpreted as if it contained `vec2v_position`, producing an `unexpected NEW_IDENTIFIER` shader compilation error.

The second commit makes the minifier emit:

```glsl
OUT(vec2) v_position;
```

This preserves the intended token boundary. It adds only semantically redundant whitespace for conforming compilers and does not change shader logic.

## Reproduction

A small static `.riv` artboard is sufficient. It should contain:

- several visible filled or stroked vector paths;
- optionally, an image mesh alongside those paths to make the failure easier to identify.

A state machine is not required.

With the Rive GPU renderer:

- on the affected Adreno compiler, image meshes remain visible while some or all vector paths disappear due to a silent shader miscompile;
- on the affected Mesa/virgl compiler, the generated path shader fails to compile and the rendered artboard is incomplete.

The Android Canvas renderer can be used as a control because it does not use these GLSL path shaders.

The Mesa preprocessing failure can also be reproduced independently with the minimal function-like macro example above; no `.riv` asset is needed for that compiler-level reproduction.

## Validation

- A/B tested the Adreno fix on Android 8.1 / Adreno 616:
  - the unguarded Rive renderer loses vector paths;
  - the guarded version restores the complete result and matches the Canvas control.
- Reproduced the Mesa failure on Android 12 / Mesa 20.3.4 / virgl:
  - the old minified shader fails with `unexpected NEW_IDENTIFIER`;
  - preserving the separator allows the shader to compile and restores the complete artboard.
- Verified both fixes together against Rive Android 11.7.2 / `runtime-v0.1.169`.
- Regenerated the complete shader set (106 generated artifacts).
- Compiled all 147 SPIR-V shader variants successfully.

Automated visual coverage for the Adreno failure is not practical because it is a silent device-driver miscompile. The Mesa change is isolated to token separation in generated GLSL and does not alter shader semantics.