### PR TITLE
feat(viewmodel): expose referenced view model name in PropertyData

### DIFF
--- a/include/rive/viewmodel/runtime/viewmodel_runtime.hpp
+++ b/include/rive/viewmodel/runtime/viewmodel_runtime.hpp
@@ -17,6 +17,7 @@ struct PropertyData
     DataType type;
     std::string name;
     std::string enumName;
+    std::string viewModelName;
 };
 
 class ViewModelRuntime : public RefCnt<ViewModelRuntime>
@@ -34,8 +35,7 @@ public:
     rcp<ViewModelInstanceRuntime> createDefaultInstance() const;
     rcp<ViewModelInstanceRuntime> createInstance() const;
     std::vector<PropertyData> properties();
-    static std::vector<PropertyData> buildPropertiesData(
-        std::vector<rive::ViewModelProperty*>& properties);
+    static std::vector<PropertyData> buildPropertiesData(ViewModel* viewModel);
     std::vector<std::string> instanceNames() const;
 
 private:

--- a/include/rive/viewmodel/viewmodel.hpp
+++ b/include/rive/viewmodel/viewmodel.hpp
@@ -28,9 +28,7 @@ public:
     rcp<ViewModelInstance> createInstance();
     rcp<ViewModelInstance> createFromInstance(const std::string& instanceName);
     void file(File* value) { m_file = value; };
-#ifdef WITH_RIVE_TOOLS
-    File* file() { return m_file; };
-#endif
+    File* file() const { return m_file; };
     ViewModelInstance* defaultInstance();
     size_t instanceCount() const;
     std::vector<ViewModelProperty*> properties() { return m_Properties; }

--- a/src/viewmodel/runtime/viewmodel_instance_runtime.cpp
+++ b/src/viewmodel/runtime/viewmodel_instance_runtime.cpp
@@ -424,7 +424,6 @@ bool ViewModelInstanceRuntime::replaceViewModelByName(
 
 std::vector<PropertyData> ViewModelInstanceRuntime::properties() const
 {
-    std::vector<PropertyData> props;
-    auto properties = m_viewModelInstance->viewModel()->properties();
-    return ViewModelRuntime::buildPropertiesData(properties);
+    return ViewModelRuntime::buildPropertiesData(
+        m_viewModelInstance->viewModel());
 }

--- a/src/viewmodel/runtime/viewmodel_runtime.cpp
+++ b/src/viewmodel/runtime/viewmodel_runtime.cpp
@@ -41,13 +41,15 @@ const std::string& ViewModelRuntime::name() const
 }
 
 std::vector<PropertyData> ViewModelRuntime::buildPropertiesData(
-    std::vector<rive::ViewModelProperty*>& properties)
+    ViewModel* viewModel)
 {
+    auto* file = viewModel->file();
     std::vector<PropertyData> props;
-    for (auto property : properties)
+    for (auto property : viewModel->properties())
     {
         DataType type = DataType::none;
         std::string enumName;
+        std::string viewModelName;
         switch (property->coreType())
         {
             case ViewModelPropertyString::typeKey:
@@ -82,8 +84,20 @@ std::vector<PropertyData> ViewModelRuntime::buildPropertiesData(
                 type = DataType::trigger;
                 break;
             case ViewModelPropertyViewModelBase::typeKey:
+            {
                 type = DataType::viewModel;
+                if (file != nullptr)
+                {
+                    auto* referencedViewModel = file->viewModel(
+                        static_cast<ViewModelPropertyViewModel*>(property)
+                            ->viewModelReferenceId());
+                    if (referencedViewModel != nullptr)
+                    {
+                        viewModelName = referencedViewModel->name();
+                    }
+                }
                 break;
+            }
             case ViewModelPropertySymbolListIndex::typeKey:
                 type = DataType::symbolListIndex;
                 break;
@@ -99,15 +113,14 @@ std::vector<PropertyData> ViewModelRuntime::buildPropertiesData(
             default:
                 break;
         }
-        props.push_back({type, property->name(), enumName});
+        props.push_back({type, property->name(), enumName, viewModelName});
     }
     return props;
 }
 
 std::vector<PropertyData> ViewModelRuntime::properties()
 {
-    auto props = m_viewModel->properties();
-    return buildPropertiesData(props);
+    return buildPropertiesData(m_viewModel);
 }
 
 std::vector<std::string> ViewModelRuntime::instanceNames() const

--- a/tests/unit_tests/runtime/data_binding_test.cpp
+++ b/tests/unit_tests/runtime/data_binding_test.cpp
@@ -1497,6 +1497,23 @@ TEST_CASE("View model runtime properties", "[data binding]")
     REQUIRE(numData != properties.end());
     REQUIRE(numData->type == rive::DataType::number);
     REQUIRE(numData->enumName.empty());
+    REQUIRE(numData->viewModelName.empty());
+
+    // View model properties expose the name of the view model they reference,
+    // both from an instance and from the view model runtime itself.
+    auto chiData = findProperty("chi");
+    REQUIRE(chiData != properties.end());
+    REQUIRE(chiData->type == rive::DataType::viewModel);
+    REQUIRE(chiData->viewModelName == "child");
+
+    auto viewModelProperties = vm->properties();
+    auto chiViewModelData = std::find_if(viewModelProperties.begin(),
+                                         viewModelProperties.end(),
+                                         [](const rive::PropertyData& data) {
+                                             return data.name == "chi";
+                                         });
+    REQUIRE(chiViewModelData != viewModelProperties.end());
+    REQUIRE(chiViewModelData->viewModelName == "child");
 }
 
 TEST_CASE("Trigger fires single change on listener", "[data binding]")


### PR DESCRIPTION
Adds `viewModelName` to `PropertyData` so callers can tell which view model a `DataType::viewModel` property references, without creating an instance just to introspect it. Symmetric with `enumName`.

A `ViewModelPropertyViewModel` only carries `viewModelReferenceId` and a `ViewModelProperty` has no link back to its owner, so the name has to be resolved through the `File`: `buildPropertiesData` now takes the owning `ViewModel` rather than its property list, and reaches the file via `ViewModel::file()`, which is no longer `WITH_RIVE_TOOLS`-only.

Needed by rive-wasm to surface `viewModelName` through `getProperties()` for TypeScript schema/codegen use cases.